### PR TITLE
Make rustup and cargo state persistent across icedragon invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Pull the base image and the image we're trying to build, to trigger
+      # a build only if neccessary:
+      #
+      # * If there is a newer base image.
+      # * If `Dockerfile` was modified.
+      - run: docker pull docker.io/gentoo/stage3:musl-llvm
+      - run: docker pull ghcr.io/${{ github.repository }}:latest
+        if: github.ref == 'refs/heads/main'
+      - run: docker pull ghcr.io/${{ github.repository }}:${{ github.head_ref }}
+        if: github.ref != 'refs/heads/main'
+
       - run: |
           cargo run build-container-image \
             --tag ghcr.io/${{ github.repository }}:latest \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,27 +19,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rust-src
-
-      - name: Run clippy
-        run: cargo clippy --all-targets --workspace -- --deny warnings
+      - run: cargo clippy --all-targets --workspace -- --deny warnings
 
   lint-nightly:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rustfmt, rust-src
-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
+      - run: cargo fmt --all -- --check
 
   build-container-image:
     runs-on: ubuntu-latest
@@ -50,26 +44,22 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build container image
-        if: github.ref == 'refs/heads/main'
-        run: |
+      - run: |
           cargo run build-container-image \
             --tag ghcr.io/${{ github.repository }}:latest \
             --push
-
-      - name: Build container image
-        if: github.ref != 'refs/heads/main'
-        run: |
+        if: github.ref == 'refs/heads/main'
+      - run: |
           cargo run build-container-image \
             --tag ghcr.io/${{ github.repository }}:${{ github.head_ref }} \
             --push
+        if: github.ref != 'refs/heads/main'
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  upload-bins:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-unknown-linux-musl
+          - x86_64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: icedragon
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.89", default-features = false }
 chrono = { version = "0.4", default-features = false }
-clap = { version = "4.5", default-features = false, features = ["derive", "help", "std"] }
+clap = { version = "4.5", default-features = false, features = ["derive", "env", "help", "std"] }
 env_logger = { version = "0.11", default-features = false }
 log = { version = "0.4", default-features = false }
 nix = { version = "0.29", default-features = false, features = ["user"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4", default-features = false }
 clap = { version = "4.5", default-features = false, features = ["derive", "help", "std"] }
 env_logger = { version = "0.11", default-features = false }
 log = { version = "0.4", default-features = false }
+nix = { version = "0.29", default-features = false, features = ["user"] }
 target-lexicon = { version = "0.12", default-features = false }
 thiserror = { version = "1.0.64", default-features = false }
 uuid = { version = "1.10", default-features = false, features = ["v4"] }

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -6,7 +6,7 @@ ARG LLVM_VERSION=19
 
 # Gentoo stores LLVM toolchains in "slotted" directories inside /usr/lib/llvm.
 # Rustup stores Rust toolchains in ~/.cargo/bin. Add these directories to PATH.
-ENV PATH="/root/.cargo/bin:/usr/lib/llvm/${LLVM_VERSION}/bin:${PATH}"
+ENV PATH="/home/icedragon/.cargo/bin:/usr/lib/llvm/${LLVM_VERSION}/bin:${PATH}"
 # Enable static libraries for installed packages (zstd, zlib etc.).
 ENV USE="static-libs"
 # Specify QEMU targets to enable.
@@ -81,13 +81,6 @@ COPY package.use/* /etc/portage/package.use/
 # * Regular expressions:
 #   * libpcre2
 #
-# Install stable and beta Rust toolchains with `default` rustup profile
-# (containing rust-docs, rustfmt, and clippy) for all supported targets.
-#
-# Install nightly Rust toolchains with `complete` rustup profile (containing
-# all components provided by rustup, available only for nightly toolchains)
-# for all supported targets.
-#
 # [0] https://wiki.gentoo.org/wiki/Crossdev
 # [1] https://github.com/llvm/llvm-project/tree/main/llvm-libgcc
 # [2] https://github.com/rust-lang/rust/issues/119504
@@ -161,14 +154,18 @@ RUN emerge-webrsync \
         sys-libs/error-standalone \
         sys-libs/fts-standalone \
         sys-libs/zlib \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && rustup toolchain install stable beta --profile=default \
-        --target=aarch64-unknown-linux-musl,x86_64-unknown-linux-musl \
-    && rustup toolchain install nightly --profile=complete \
-        --target=aarch64-unknown-linux-musl,x86_64-unknown-linux-musl \
-    && cargo install btfdump \
+    && useradd -m -G users -s /bin/bash icedragon \
     && rm -rf \
         /var/cache/binpkgs/* \
         /var/cache/distfiles/* \
         /var/db/repos/* \
         /var/tmp/portage/*
+
+COPY entrypoint.sh /entrypoint.sh
+
+USER icedragon
+# Ensure that the mount targets for named volumes are owned by the `icedragon`
+# user.
+RUN mkdir /home/icedragon/{.cargo,.rustup}
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -6,7 +6,7 @@ ARG LLVM_VERSION=19
 
 # Gentoo stores LLVM toolchains in "slotted" directories inside /usr/lib/llvm.
 # Rustup stores Rust toolchains in ~/.cargo/bin. Add these directories to PATH.
-ENV PATH="/home/icedragon/.cargo/bin:/usr/lib/llvm/${LLVM_VERSION}/bin:${PATH}"
+ENV PATH="/home/icedragon/.cargo/bin:/opt/icedragon/bin:/usr/lib/llvm/${LLVM_VERSION}/bin:${PATH}"
 # Enable static libraries for installed packages (zstd, zlib etc.).
 ENV USE="static-libs"
 # Specify QEMU targets to enable.
@@ -91,6 +91,9 @@ RUN emerge-webrsync \
         app-eselect/eselect-repository \
         llvm-runtimes/libgcc \
         sys-devel/crossdev \
+    && mkdir -p /opt/icedragon/bin \
+    && curl -L https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$(arch)-unknown-linux-musl.tgz \
+        | tar -zxpf - -C /opt/icedragon/bin \
     && eselect repository create crossdev \
     && crossdev --llvm --target aarch64-unknown-linux-musl \
     && curl -L "https://ftp-osl.osuosl.org/pub/gentoo/releases/arm64/autobuilds/current-stage3-arm64-musl-llvm/$(\

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -89,6 +89,7 @@ RUN emerge-webrsync \
     && emerge \
         app-emulation/qemu \
         app-eselect/eselect-repository \
+        app-misc/ca-certificates \
         llvm-runtimes/libgcc \
         sys-devel/crossdev \
     && mkdir -p /opt/icedragon/bin \

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Entrypoint script that installs rustup if it is not already available.
+# The `~/.cargo` and `~/.rustup` directories are mounted as volumes and are not
+# part of the container image. This design decision allows persistence of
+# binary crates and additional Rust toolchains installed by users.
+
+set -e
+
+if ! which rustup > /dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+  # Install stable Rust toolchain with `default` rustup profile (containing
+  # rust-docs, rustfmt, and clippy) for all supported targets.
+  rustup toolchain install stable --profile=default \
+    --target=aarch64-unknown-linux-musl,x86_64-unknown-linux-musl
+fi
+
+"$@"

--- a/containers/package.accept_keywords/icedragon
+++ b/containers/package.accept_keywords/icedragon
@@ -40,6 +40,6 @@
 # llvm-runtimes/libgcc is undergoing testing for amd64 and provides no keywords
 # for the rest of architectures. Unmask it with `**`. Our CI proves that it works
 # with arm64.
-=llvm-runtimes/libgcc-19.1.7 **
+=llvm-runtimes/libgcc-19.1.7-r1 **
 # libgcc requires a testing version (19.1.7) of libunwind.
 =llvm-runtimes/libunwind-19.1.7

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,11 @@ fn build_container_image(
 #[derive(Parser)]
 struct RunArgs {
     /// Container image to use.
-    #[arg(long, default_value = "ghcr.io/exein-io/icedragon:latest")]
+    #[arg(
+        long,
+        env = "ICEDRAGON_CONTAINER_IMAGE",
+        default_value = "ghcr.io/exein-io/icedragon:latest"
+    )]
     pub container_image: OsString,
 
     /// Additional volumes to mount to the container.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::{
     ffi::{OsStr, OsString},
     io::{BufRead as _, BufReader, Write as _},
     iter,
+    os::unix::ffi::OsStrExt as _,
     process::{Command, Stdio},
     str::FromStr as _,
     thread,
@@ -293,27 +294,41 @@ struct RunArgs {
 /// Takes a `cmd`, representing a container engine, and adds `--env` arguments,
 /// consisting of:
 ///
-/// * The current environment variables, except `PATH`, which should be
-///   inherited from the Dockerfile.
+/// * The current environment variables, except `HOME`, `PATH`, `USER`, the
+///   ones related to the Rust ecosystem (with `CARGO_` and `RUSTUP_` prefix)
+///   and to SSL certificates (with `SSL_` prefix), which should remain
+///   unchanged.
 /// * Additional variables defined by us:
 ///   * `CXXFLAGS` and `LDFLAGS`, pointing to LLVM libc++ as a C++ stdlib, LLD
 ///     as a linker, compiler-rt as a runtime library and LLVM libunwind as
 ///     unwinder.
 ///   * `PKG_CONFIG_SYSROOT_DIR`, to point pkg-config to the sysroot.
+/// * Variables extended with values defined by us:
+///   * `RUSTFLAGS`, which we extend with the `linker` and `link-arg` options,
+///     enforcing the usage of clang as a linker and pointing to the cross
+///     sysroot.
 fn add_env_args(cmd: &mut Command, triple: &Triple) {
     for (key, value) in env::vars_os() {
-        if key != "PATH" {
-            let mut env_arg = OsString::from("--env=");
-            env_arg.push(key);
-            env_arg.push("=");
-            env_arg.push(value);
-            cmd.arg(env_arg);
+        let key_b = key.as_bytes();
+        if key == "HOME"
+            || key == "PATH"
+            || key == "USER"
+            || key_b.starts_with(b"CARGO_")
+            || key_b.starts_with(b"RUSTUP_")
+            || key_b.starts_with(b"SSL")
+        {
+            continue;
         }
+
+        let mut env_arg = OsString::from("--env=");
+        env_arg.push(key);
+        env_arg.push("=");
+        env_arg.push(value);
+        cmd.arg(env_arg);
     }
     cmd.arg("--env=CXXFLAGS=--stdlib=libc++");
     cmd.arg("--env=LDFLAGS=-fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind");
     cmd.arg(format!("--env=PKG_CONFIG_SYSROOT_DIR=/usr/{triple}"));
-    cmd.arg("--env=RUSTUP_HOME=/root/.rustup");
 
     let mut rustflags_arg = OsString::from("--env=RUSTFLAGS=");
     rustflags_arg.push(env::var_os("RUSTFLAGS").unwrap_or_default());
@@ -349,6 +364,8 @@ fn run_container(
     volumes: impl IntoIterator<Item = impl AsRef<OsStr>>,
     cmd_args: impl IntoIterator<Item = impl AsRef<OsStr>>,
 ) -> anyhow::Result<()> {
+    let uid = nix::unistd::getuid();
+
     let mut bind_mount = env::current_dir()?.into_os_string();
     bind_mount.push(":/src");
 
@@ -358,7 +375,17 @@ fn run_container(
     if interactive {
         container.arg("-it");
     }
-    container.args(["--rm", "-v"]).arg(&bind_mount);
+    container.args(["--rm", "--user"]);
+    container.arg(uid.to_string());
+    container
+        .args([
+            "-v",
+            "cargo:/home/icedragon/.cargo",
+            "-v",
+            "rustup:/home/icedragon/.rustup",
+            "-v",
+        ])
+        .arg(&bind_mount);
     for volume in volumes {
         container.arg("-v");
         container.arg(volume);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -135,6 +135,23 @@ where
     assert_eq!(elf.header.e_machine, elf_machine);
 }
 
+/// Tests whether:
+///
+/// * We can install projects with cargo-binstall into the cargo
+///   volume.
+/// * The installed artifacts are persistent across icedragon invocations.
+#[test]
+fn test_cargo_binstall() {
+    let current_dir = env::current_dir().unwrap();
+    let target = format!("{}", target_lexicon::HOST);
+    icedragon_cmd(&current_dir, "cargo", &target)
+        .args(["binstall", "-y", "cargo-hack"])
+        .assert_success();
+    icedragon_cmd(&current_dir, "run", &target)
+        .args(["which", "cargo-hack"])
+        .assert_success();
+}
+
 /// Tests cargo support by cross-compiling pulsar.
 #[test_case("aarch64-unknown-linux-musl", elf_header::EM_AARCH64 ; "aarch64")]
 #[test_case("x86_64-unknown-linux-musl", elf_header::EM_X86_64 ; "x86_64")]


### PR DESCRIPTION
Make any changes made by users to the Rustup toolchains and `~/.cargo` directory persistent by creating named volumes for `~/.cargo` and `~/.rustup`. Create a regular user `icedragon` to ensure rustup works correctly.

Install cargo-binstall, which allows for quick installation of binaries. It's convenient to have it already in the container.

Add a release workflow. This will make icedragon available for cargo-binstall.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exein-io/icedragon/3)
<!-- Reviewable:end -->
